### PR TITLE
Correct handling of shape parameter.

### DIFF
--- a/lineage/states/stateCommon.py
+++ b/lineage/states/stateCommon.py
@@ -81,7 +81,12 @@ def gamma_estimator(gamma_obs, time_censor_obs, gammas, shape):
     assert cens_gammas.shape[0] == cens_obs.shape[0]
 
     arrgs = (uncens_obs, uncens_gammas, cens_obs, cens_gammas)
-    res = minimize(fun=negative_LL_jit, jac=True, x0=np.log(x0), method="TNC", bounds=((None, 5.0), (None, 5.0)), args=arrgs)
+    if shape is None:
+        bnds = ((None, 5.0), (None, 5.0))
+    else:
+        bnds = ((np.log(shape) - 0.01, np.log(shape) + 0.01), (None, 5.0))
+
+    res = minimize(fun=negative_LL_jit, jac=True, x0=np.log(x0), method="TNC", bounds=bnds, args=arrgs)
     return np.exp(res.x)
 
 


### PR DESCRIPTION
This should correct the estimator so that the shape is fixed when there is censored data. This can be merged if everything builds correctly.