### PR TITLE
Fixed constrained optimization

### DIFF
--- a/lineage/states/stateCommon.py
+++ b/lineage/states/stateCommon.py
@@ -145,6 +145,6 @@ def gamma_estimator_atonce(gamma_obs, time_cen, gamas, x0=None):
 
     linc = LinearConstraint(A, lb=np.zeros(3), ub=np.ones(3)*100.0, keep_feasible=True)
     bnds = Bounds(lb=np.zeros_like(x0), ub=np.ones_like(x0)*100.0, keep_feasible=True)
-    res = minimize(negative_LL_atonce, x0=x0, args=arrgs, method="trust-constr", hess="3-point", bounds=bnds, constraints=[linc])
+    res = minimize(negative_LL_atonce, x0=x0, args=arrgs, method="trust-constr", hess="HessianUpdateStrategy", bounds=bnds, constraints=[linc])
 
     return res.x

--- a/lineage/states/stateCommon.py
+++ b/lineage/states/stateCommon.py
@@ -145,6 +145,6 @@ def gamma_estimator_atonce(gamma_obs, time_cen, gamas, x0=None):
 
     linc = LinearConstraint(A, lb=np.zeros(3), ub=np.ones(3)*100.0, keep_feasible=True)
     bnds = Bounds(lb=np.zeros_like(x0), ub=np.ones_like(x0)*100.0, keep_feasible=True)
-    res = minimize(negative_LL_atonce, x0=x0, args=arrgs, method="trust-constr", hess="HessianUpdateStrategy", bounds=bnds, constraints=[linc])
+    res = minimize(negative_LL_atonce, x0=x0, args=arrgs, method="trust-constr", bounds=bnds, constraints=[linc])
 
     return res.x

--- a/lineage/states/stateCommon.py
+++ b/lineage/states/stateCommon.py
@@ -143,8 +143,8 @@ def gamma_estimator_atonce(gamma_obs, time_cen, gamas, x0=None):
     if np.allclose(np.dot(A, x0), 0.0):
         x0 = np.array([20.0, 2.0, 3.0, 4.0, 5.0])
 
-    linc = LinearConstraint(A, lb=np.zeros(3), ub=np.ones(3)*100.0, keep_feasible=True)
-    bnds = Bounds(lb=np.zeros_like(x0), ub=np.ones_like(x0)*100.0, keep_feasible=True)
+    linc = LinearConstraint(A, lb=np.zeros(3), ub=np.ones(3)*100.0)
+    bnds = Bounds(lb=np.zeros_like(x0), ub=np.ones_like(x0)*100.0)
     res = minimize(negative_LL_atonce, x0=x0, args=arrgs, method="trust-constr", bounds=bnds, constraints=[linc])
 
     return res.x

--- a/lineage/states/stateCommon.py
+++ b/lineage/states/stateCommon.py
@@ -145,6 +145,6 @@ def gamma_estimator_atonce(gamma_obs, time_cen, gamas, x0=None):
 
     linc = LinearConstraint(A, lb=np.zeros(3), ub=np.ones(3)*100.0, keep_feasible=True)
     bnds = Bounds(lb=np.zeros_like(x0), ub=np.ones_like(x0)*100.0, keep_feasible=True)
-    res = minimize(negative_LL_atonce, x0=x0, args=arrgs, method="trust-constr", bounds=bnds, constraints=[linc])
+    res = minimize(negative_LL_atonce, x0=x0, args=arrgs, method="trust-constr", hess="3-point", bounds=bnds, constraints=[linc])
 
     return res.x


### PR DESCRIPTION
The COBYLA optimization turned out to be very bad for this problem, because of the high interdependency between shape and scale. It basically works within square regions of parameter space, so it was spending huge numbers of iterations slightly increasing shape and then slightly decreasing all the scales to compensate.

The trust-region solver is much more mature, so that is implemented here. The other problem was that the first `x0` provided was bad (I mentioned this might be the case). All the scales were the same, which was causing some issue in the solver. I have a quick fix here, but really the tHMM should be providing `x0=None` on the first iteration.