### PR TITLE
pagebreak

### DIFF
--- a/manuscript/01.introduction.md
+++ b/manuscript/01.introduction.md
@@ -1,4 +1,4 @@
-## Introduction
+## Introduction {.page_break_before}
 
 <!-- motivation; heterogeneity is an obstacle for chemotherapy  -->
 Chemotherapy and targeted therapies that selectively eliminate fast-proliferating or oncogene-addicted cells, are among the primary treatments of cancer. However, long-term therapeutic efficacy varies significantly due in part to widespread intratumoral heterogeneity [@pmid:16129367; @PMID:20619739]. Cell variability in drug response can originate from cell-intrinsic factors—such as genomic alterations, epigenetic mechanisms like changes in chromatin state [@pmid:20371346], and variable protein levels [@pmid:19363473; @doi:10.1038/nature05316]—or cell-extrinsic factors such as spatial variability in the surrounding vasculature and environmental stressors [@doi:10.1038/nrg.2016.13; @pmid:25131830; @pmid:29250983]. Moreover, cell plasticity, where cells adopt the characteristics of other cell types, is observed in cancer cells and can affect their sensitivity to therapy [@doi:10.1038/bjc.2015.146].

--- a/manuscript/05.methods.md
+++ b/manuscript/05.methods.md
@@ -121,7 +121,7 @@ In this part we briefly mention the measures used to quantify the model goodness
  
 The Wasserstein or Kantorovich–Rubinstein metric is a measure of distance between two distributions. This metric was used to determine the difference between state emissions [@doi:10.1137/1118101]. An analytical solution, the absolute value of the difference in distribution means, was used for the Gamma distribution.
 
-### Model benchmarking {.page_break_before}
+### Model benchmarking
 
 We used emission distributions to represent the phenotypic characteristics of the cells within the lineages. To create our synthetic data we considered two possible options as our set of observations throughout an experiment. In one case, we modeled cell fate and cell lifetime, and in the second, phase-specific fate and duration. In both, we used a Bernoulli distribution for the fate outcomes and a Gamma distribution for time durations. Following is the collection of distribution parameters for the synthetic data.
 

--- a/manuscript/05.methods.md
+++ b/manuscript/05.methods.md
@@ -121,7 +121,7 @@ In this part we briefly mention the measures used to quantify the model goodness
  
 The Wasserstein or Kantorovich–Rubinstein metric is a measure of distance between two distributions. This metric was used to determine the difference between state emissions [@doi:10.1137/1118101]. An analytical solution, the absolute value of the difference in distribution means, was used for the Gamma distribution.
 
-### Model benchmarking
+### Model benchmarking {.page_break_before}
 
 We used emission distributions to represent the phenotypic characteristics of the cells within the lineages. To create our synthetic data we considered two possible options as our set of observations throughout an experiment. In one case, we modeled cell fate and cell lifetime, and in the second, phase-specific fate and duration. In both, we used a Bernoulli distribution for the fate outcomes and a Gamma distribution for time durations. Following is the collection of distribution parameters for the synthetic data.
 


### PR DESCRIPTION
The "introduction" was at the end of the first page and the text was in the next page, so I put a `{.page_break_before}` to bring the "introduction" to the next page. 
It was the case with some part in the methods, too. I don't know if it is possible to view the manuscript build and convert it to pdf before we merge..

Other than that I guess it looks fine.