### PR TITLE
Align CI with org-wide shared Python workflow template

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,8 @@
 name: Test
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   build:
@@ -11,6 +13,8 @@ jobs:
         run: git submodule update --init --recursive
       - name: Install uv
         uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
       - name: Install dependencies
         run: uv sync
       - name: Lint with ruff


### PR DESCRIPTION
## Summary
- Adds `pull_request` as a trigger alongside `push`, and enables uv's dependency cache, matching the pattern in [meyer-lab/.github's `python-uv-ruff-pytest` template](https://github.com/meyer-lab/.github/pull/2).
- Submodule setup and the custom pytest coverage config (`--cov=lineage --cov-report=xml --cov-config=.github/workflows/coveragerc`) are kept as-is since they're specific to this repo.

## Test plan
- [ ] CI passes on this PR